### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require hammerstone/airdrop
 
 Once the package is installed, you may optionally publish the config file by running 
 ```console
-php artisan airdop:install
+php artisan airdrop:install
 ```
 
 You'll likely want to publish the config file so that you can set up your triggers and outputs.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -14,7 +14,7 @@ This will take care of downloading and uploading your assets, should that be req
 Once you're done, your asset step will look something like this:
 
 ```bash
-php artisan airdop:download
+php artisan airdrop:download
 npm run production
 php artisan airdrop:upload
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ composer require hammerstone/airdrop
 
 Once the package is installed, you may optionally publish the config file by running 
 ```console
-php artisan airdop:install
+php artisan airdrop:install
 ```
 
 You'll likely want to publish the config file so that you can set up your triggers and outputs.


### PR DESCRIPTION
Hey,

love the idea behind this package. I'm testing it currently.
When installing I found some typos in the docs.